### PR TITLE
Allow multiple prefixes to be restricted instead of just admin

### DIFF
--- a/sfdo_template_helpers/admin/middleware.py
+++ b/sfdo_template_helpers/admin/middleware.py
@@ -16,8 +16,12 @@ class AdminRestrictMiddleware:
         self.ip_ranges = settings.ADMIN_API_ALLOWED_SUBNETS
 
     def __call__(self, request):
-        if request.path.startswith(f"/{settings.ADMIN_AREA_PREFIX}"):
-            self._validate_ip(request)
+        restricted_areas = tuple(getattr(settings, "RESTRICTED_PREFIXES", ()))
+        restricted_areas += tuple([getattr(settings, "ADMIN_AREA_PREFIX", ())])
+
+        for area in restricted_areas:
+            if request.path.startswith(f"/{area}"):
+                self._validate_ip(request)
 
         return self.get_response(request)
 

--- a/sfdo_template_helpers/admin/middleware.py
+++ b/sfdo_template_helpers/admin/middleware.py
@@ -17,9 +17,12 @@ class AdminRestrictMiddleware:
 
     def __call__(self, request):
         restricted_areas = tuple(getattr(settings, "RESTRICTED_PREFIXES", ()))
-        restricted_areas += tuple([getattr(settings, "ADMIN_AREA_PREFIX", ())])
+        admin_area = getattr(settings, "ADMIN_AREA_PREFIX", None)
+        if admin_area is not None:
+            restricted_areas += (admin_area,)
 
         for area in restricted_areas:
+            print(request.path, "VS", area, "FROM", restricted_areas)
             if request.path.startswith(f"/{area}"):
                 self._validate_ip(request)
 
@@ -28,6 +31,8 @@ class AdminRestrictMiddleware:
     def _validate_ip(self, request):
         ip_str = get_remote_ip(request)
         ip_addr = IPv4Address(ip_str)
+
+        print("Validating", ip_addr, "Vs", self.ip_ranges)
 
         if not any(ip_addr in subnet for subnet in self.ip_ranges):
             raise SuspiciousOperation(f"Disallowed IP address: {ip_addr}")

--- a/sfdo_template_helpers/admin/middleware.py
+++ b/sfdo_template_helpers/admin/middleware.py
@@ -22,7 +22,7 @@ class AdminRestrictMiddleware:
             restricted_areas += (admin_area,)
 
         for area in restricted_areas:
-            print(request.path, "VS", area, "FROM", restricted_areas)
+            area = area.rstrip("/")
             if request.path.startswith(f"/{area}"):
                 self._validate_ip(request)
 
@@ -31,8 +31,6 @@ class AdminRestrictMiddleware:
     def _validate_ip(self, request):
         ip_str = get_remote_ip(request)
         ip_addr = IPv4Address(ip_str)
-
-        print("Validating", ip_addr, "Vs", self.ip_ranges)
 
         if not any(ip_addr in subnet for subnet in self.ip_ranges):
             raise SuspiciousOperation(f"Disallowed IP address: {ip_addr}")

--- a/tests/test_admin_middleware.py
+++ b/tests/test_admin_middleware.py
@@ -68,7 +68,7 @@ class TestAdminRestrictMiddleware:
         with pytest.raises(SuspiciousOperation):
             middleware._validate_ip(request)
 
-    def test_validate_restriction_on_multiple_URLs(self, settings):
+    def test_validate_restriction_on_multiple_prefixes(self, settings):
         settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
         settings.RESTRICTED_PREFIXES = ["admin/", "topsecret/"]
 

--- a/tests/test_admin_middleware.py
+++ b/tests/test_admin_middleware.py
@@ -41,6 +41,18 @@ class TestAdminRestrictMiddleware:
         middleware = AdminRestrictMiddleware(get_response)
         assert middleware(request) == sentinel.get_response_return
 
+    def test_bad_ip_blocked(self, settings):
+        settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
+        settings.ADMIN_AREA_PREFIX = "admin"
+
+        def get_response(request):
+            return sentinel.get_response_return
+
+        request = Request({"HTTP_X_FORWARDED_FOR": "0.0.0.0"}, "/admin")
+        middleware = AdminRestrictMiddleware(get_response)
+        with pytest.raises(SuspiciousOperation):
+            middleware(request)
+
     def test_validate_ip_valid(self, settings):
         settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
 
@@ -56,21 +68,23 @@ class TestAdminRestrictMiddleware:
         with pytest.raises(SuspiciousOperation):
             middleware._validate_ip(request)
 
-    def test_validate_ip_invalid_multiple_URLs(self, settings):
+    def test_validate_restriction_on_multiple_URLs(self, settings):
         settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
         settings.RESTRICTED_PREFIXES = ["admin/", "topsecret/"]
 
+        def get_response(request):
+            return sentinel.get_response_return
+
         request = Request({"HTTP_X_FORWARDED_FOR": "0.0.0.0"}, "/topsecret")
-        middleware = AdminRestrictMiddleware(None)
+        middleware = AdminRestrictMiddleware(get_response)
         with pytest.raises(SuspiciousOperation):
-            middleware._validate_ip(request)
+            middleware(request)
 
     def test_validate_ip_irrelevant_multiple_URLs(self, settings):
         settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
         settings.RESTRICTED_PREFIXES = ["admin/", "topsecret/"]
 
         request = Request({"HTTP_X_FORWARDED_FOR": "0.0.0.0"}, "/nottopsecret")
-
         def get_response(request):
             return sentinel.get_response_return
 

--- a/tests/test_admin_middleware.py
+++ b/tests/test_admin_middleware.py
@@ -55,3 +55,36 @@ class TestAdminRestrictMiddleware:
         middleware = AdminRestrictMiddleware(None)
         with pytest.raises(SuspiciousOperation):
             middleware._validate_ip(request)
+
+    def test_validate_ip_invalid_multiple_URLs(self, settings):
+        settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
+        settings.RESTRICTED_PREFIXES = ["admin/", "topsecret/"]
+
+        request = Request({"HTTP_X_FORWARDED_FOR": "0.0.0.0"}, "/topsecret")
+        middleware = AdminRestrictMiddleware(None)
+        with pytest.raises(SuspiciousOperation):
+            middleware._validate_ip(request)
+
+    def test_validate_ip_irrelevant_multiple_URLs(self, settings):
+        settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
+        settings.RESTRICTED_PREFIXES = ["admin/", "topsecret/"]
+
+        request = Request({"HTTP_X_FORWARDED_FOR": "0.0.0.0"}, "/nottopsecret")
+
+        def get_response(request):
+            return sentinel.get_response_return
+
+        request = Request({"HTTP_X_FORWARDED_FOR": "127.0.0.1"}, "/admin")
+        middleware = AdminRestrictMiddleware(get_response)
+        assert middleware(request) == sentinel.get_response_return
+
+    def test_validate_ip_valid_multiple_URLs(self, settings):
+        settings.ADMIN_API_ALLOWED_SUBNETS = [IPv4Network("127.0.0.1")]
+        settings.RESTRICTED_PREFIXES = ["admin/", "topsecret/"]
+
+        def get_response(request):
+            return sentinel.get_response_return
+
+        request = Request({"HTTP_X_FORWARDED_FOR": "127.0.0.1"}, "/topsecret")
+        middleware = AdminRestrictMiddleware(get_response)
+        assert middleware(request) == sentinel.get_response_return


### PR DESCRIPTION
This is because we would like to also IP-block access to REST APIs in MetaCI. Other use cases may present themselves over time.