### PR TITLE
Change username for users created via Salesforce oauth login

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name="sfdo-template-helpers",  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.16.0",  # Required
+    version="0.17.0",  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="A set of Django helpers and utils used by sfdo-template projects.",
     # https://packaging.python.org/specifications/core-metadata/#description-optional

--- a/sfdo_template_helpers/oauth2/salesforce/provider.py
+++ b/sfdo_template_helpers/oauth2/salesforce/provider.py
@@ -16,7 +16,11 @@ class SFDOSalesforceProvider(SalesforceProvider):
         # but it can be the same between multiple sandboxes that were
         # copied from the same production org. So we need to add the org id
         # too to disambiguate.
-        return "{}/{}".format(data["organization_id"], data["user_id"])
+        return f"{data['organization_id']}/{data['user_id']}"
+
+    def extract_common_fields(self, data):
+        # Get fields used to populate the Django user.
+        return {"username": f"{data['organization_id']}_{data['user_id']}"}
 
 
 provider_classes = [SFDOSalesforceProvider]

--- a/sfdo_template_helpers/oauth2/salesforce/tests/test_provider.py
+++ b/sfdo_template_helpers/oauth2/salesforce/tests/test_provider.py
@@ -12,3 +12,12 @@ def test_extract_uid(rf):
     provider = SFDOSalesforceProvider(request)
     result = provider.extract_uid({"organization_id": "ORG", "user_id": "USER"})
     assert result == "ORG/USER"
+
+
+def test_extract_common_fields(rf):
+    request = rf.get("/")
+    provider = SFDOSalesforceProvider(request)
+    result = provider.extract_common_fields(
+        {"organization_id": "ORG", "user_id": "USER"}
+    )
+    assert result == {"username": "ORG_USER"}


### PR DESCRIPTION
Previously the Salesforce username was used as the Django username. This makes it harder to comply with GDPR and can collide with an existing user if it's a sandbox user and the sandbox was refreshed. This switches to using the org id and user id concatenated with an underscore.