### PR TITLE
Support prefetching slugs

### DIFF
--- a/tests/test_slugs.py
+++ b/tests/test_slugs.py
@@ -1,6 +1,5 @@
 import pytest
 
-from sfdo_template_helpers.slugs import AbstractSlug
 from tests.models import Foo, FooSlug
 
 
@@ -40,7 +39,27 @@ class TestSlugMixin:
         foo.slugs.update(is_active=True)
         assert foo.old_slugs == ["foold"]
 
+    def test_prefetch_related(self, django_assert_max_num_queries):
+        for i in range(10):
+            # 10 Foo instances with two slugs each
+            foo = Foo.objects.create(name=f"Foo {i}")
+            foo.ensure_slug()
+            foo.name = f"Bar {i}"
+            foo.save()
+            foo.ensure_slug()
+
+        with django_assert_max_num_queries(2):
+            # One query for all Foos and another for all FooSlugs
+            qs = Foo.objects.prefetch_related("slugs")
+            results = [foo.pk for foo in qs]
+            slugs = [foo.slug for foo in qs]
+            old_slugs = [foo.old_slugs for foo in qs]
+
+        assert len(results) == 10
+        assert len(slugs) == 10
+        assert len(old_slugs) == 10
+
 
 def test_slug_str():
-    slug = AbstractSlug(slug="nop")
+    slug = FooSlug(slug="nop")
     assert str(slug) == "nop"


### PR DESCRIPTION
Given the following code (using the [example models](https://github.com/SFDO-Tooling/sfdo-template-helpers/blob/master/tests/models.py#L27-L29)):

```python
results = [
    {"id": foo.id, "slug": foo.slug, "old_slugs": foo.old_slugs}
    for foo in Foo.objects.all()
]
```

Assuming a total of 10 `Foo` objects it results in 21 queries:

- One query to fetch all `Foo` instances
- One query for each `foo.slug`
- One query for each `foo.old_slugs`

With Django's `prefetch_related` we should be able to bring this down to two queries: one for all `Foo`s and one for all slugs:

```python
for foo in Foo.objects.prefetch_related("slugs")
```

However the current implementation [filters the `slugs` queryset](https://github.com/SFDO-Tooling/sfdo-template-helpers/blob/c2512f7ecb7900da3ccfe5a217c0ca992cc3c1de/sfdo_template_helpers/slugs.py#L48-L58) and the prefetch optimization is not possible as explained in the [docs](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#prefetch-related):

> Remember that, as always with QuerySets, any subsequent chained methods which imply a different database query will ignore previously cached results, and retrieve data using a fresh database query.

This PR uses a single, unfiltered slug queryset to get both `foo.slug` and `foo.old_slugs` making it possible to use `prefetch_related` in the parent queryset. A new test was also added to verify the optimization is not unknowingly removed.