### PR TITLE
Read custom domain from POST data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name="sfdo-template-helpers",  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.19.0",  # Required
+    version="0.20.0",  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="A set of Django helpers and utils used by sfdo-template projects.",
     # https://packaging.python.org/specifications/core-metadata/#description-optional

--- a/sfdo_template_helpers/oauth2/salesforce/tests/test_views.py
+++ b/sfdo_template_helpers/oauth2/salesforce/tests/test_views.py
@@ -14,25 +14,25 @@ from ..views import (
 
 class TestSalesforceOAuth2Adapter:
     def test_base_url(self, rf):
-        request = rf.get("/")
+        request = rf.post("/")
         request.session = {}
         adapter = SalesforceOAuth2Adapter(request)
         assert adapter.base_url == "https://login.salesforce.com"
 
     def test_base_url__sandbox(self, rf):
-        request = rf.get("/?custom_domain=test")
+        request = rf.post("/", {"custom_domain":"test"})
         request.session = {}
         adapter = SalesforceOAuth2Adapter(request)
         assert adapter.base_url == "https://test.salesforce.com"
 
     def test_base_url__custom_domain(self, rf):
-        request = rf.get("/?custom_domain=foo-bar.baz")
+        request = rf.post("/",{"custom_domain":"foo-bar.baz"})
         request.session = {}
         adapter = SalesforceOAuth2Adapter(request)
         assert adapter.base_url == "https://foo-bar.baz.my.salesforce.com"
 
     def test_base_url__invalid_domain(self, rf):
-        request = rf.get("/?custom_domain=google.com?-")
+        request = rf.post("/",{"custom_domain":"google.com?-"})
         request.session = {}
         with pytest.raises(SuspiciousOperation):
             SalesforceOAuth2Adapter(request).base_url
@@ -49,7 +49,7 @@ class TestSalesforceOAuth2Adapter:
             "urls": mock.MagicMock(),
         }
         get.side_effect = [userinfo_mock, mock.MagicMock(), mock.MagicMock()]
-        request = rf.get("/")
+        request = rf.post("/")
         request.session = {"socialaccount_state": (None, "some-verifier")}
         adapter = SalesforceOAuth2Adapter(request)
         adapter.get_provider = mock.MagicMock()
@@ -75,7 +75,7 @@ class TestSalesforceOAuth2Adapter:
             "userSettings": {"canModifyAllData": False}
         }
         get.side_effect = [mock.MagicMock(), insufficient_perms_mock]
-        request = rf.get("/")
+        request = rf.post("/")
         request.session = {"socialaccount_state": (None, "some-verifier")}
         adapter = SalesforceOAuth2Adapter(request)
         adapter.get_provider = mock.MagicMock()
@@ -109,7 +109,7 @@ class TestSalesforceOAuth2Adapter:
         ]
 
         get.side_effect = [userinfo_mock, mock.MagicMock(), api_disabled_mock]
-        request = rf.get("/")
+        request = rf.post("/")
         request.session = {"socialaccount_state": (None, "some-verifier")}
         adapter = SalesforceOAuth2Adapter(request)
         adapter.get_provider = mock.MagicMock()
@@ -133,7 +133,7 @@ class TestSalesforceOAuth2Adapter:
             "userSettings": {"canModifyAllData": False}
         }
         get.side_effect = [mock.MagicMock(), insufficient_perms_mock]
-        request = rf.get("/")
+        request = rf.post("/")
         request.session = {"socialaccount_state": (None, "some-verifier")}
         adapter = SalesforceOAuth2Adapter(request)
         adapter.get_provider = mock.MagicMock()
@@ -161,7 +161,7 @@ class TestSalesforceOAuth2Adapter:
         assert "token" == fernet_decrypt(token.token)
 
     def test_validate_org_id__invalid(self, rf):
-        request = rf.get("/")
+        request = rf.post("/")
         adapter = SalesforceOAuth2Adapter(request)
         with pytest.raises(SuspiciousOperation):
             adapter._validate_org_id("bogus")

--- a/sfdo_template_helpers/oauth2/salesforce/tests/test_views.py
+++ b/sfdo_template_helpers/oauth2/salesforce/tests/test_views.py
@@ -20,19 +20,19 @@ class TestSalesforceOAuth2Adapter:
         assert adapter.base_url == "https://login.salesforce.com"
 
     def test_base_url__sandbox(self, rf):
-        request = rf.post("/", {"custom_domain":"test"})
+        request = rf.post("/", {"custom_domain": "test"})
         request.session = {}
         adapter = SalesforceOAuth2Adapter(request)
         assert adapter.base_url == "https://test.salesforce.com"
 
     def test_base_url__custom_domain(self, rf):
-        request = rf.post("/",{"custom_domain":"foo-bar.baz"})
+        request = rf.post("/", {"custom_domain": "foo-bar.baz"})
         request.session = {}
         adapter = SalesforceOAuth2Adapter(request)
         assert adapter.base_url == "https://foo-bar.baz.my.salesforce.com"
 
     def test_base_url__invalid_domain(self, rf):
-        request = rf.post("/",{"custom_domain":"google.com?-"})
+        request = rf.post("/", {"custom_domain": "google.com?-"})
         request.session = {}
         with pytest.raises(SuspiciousOperation):
             SalesforceOAuth2Adapter(request).base_url

--- a/sfdo_template_helpers/oauth2/salesforce/views.py
+++ b/sfdo_template_helpers/oauth2/salesforce/views.py
@@ -29,7 +29,8 @@ class SalesforcePermissionsError(Exception):
 class SalesforceOAuth2Adapter(SalesforceOAuth2BaseAdapter):
     @property
     def base_url(self):
-        custom_domain = self.request.GET.get(
+        # For security assume this view is called by POST
+        custom_domain = self.request.POST.get(
             "custom_domain", self.request.session.get("custom_domain")
         )
         if custom_domain and not CUSTOM_DOMAIN_RE.match(custom_domain):


### PR DESCRIPTION
`django-allauth` disables logging in via GET by default since [version 0.47.0](https://django-allauth.readthedocs.io/en/latest/release-notes.html#security-notice). This change reads the `custom_domain` from POST instead of GET to comply with the upstream change.